### PR TITLE
feat(DoxenCodeBox): add object serialization for code prop

### DIFF
--- a/lib/components/DoxenCodeBox.vue
+++ b/lib/components/DoxenCodeBox.vue
@@ -55,7 +55,7 @@ export default {
       default: true
     },
     code: {
-      type: [String, Object],
+      type: null,
       default: undefined
     },
     styleTokens
@@ -83,10 +83,10 @@ export default {
   },
   computed: {
     formattedCode: function () {
-      if (typeof this.code === 'object' && this.code !== null) {
-        return serializeJavaScript(this.code);
+      if (typeof(this.code) === 'string') {
+        return this.code;
       }
-      return this.code;
+      return serializeJavaScript(this.code);
     },
     language: function () {
       if (this.code.trim().startsWith('<')) {

--- a/lib/components/DoxenCodeBox.vue
+++ b/lib/components/DoxenCodeBox.vue
@@ -12,7 +12,7 @@
     <HighlightJS
       v-bind="applyStyleTokens({ codeBox: true })"
       :autodetect="false"
-      :code="code"
+      :code="formattedCode"
       :language="language"
       :key="index"
     />
@@ -33,6 +33,7 @@ import javascript from 'highlight.js/lib/languages/javascript';
 import xml from 'highlight.js/lib/languages/xml';
 
 import { styleTokens } from '@/helpers/props.js';
+import { serializeJavaScript } from '@/helpers/serializeJavaScript.js';
 
 import applyStyleTokens from '@/mixins/applyStyleTokensMixin.js';
 
@@ -54,7 +55,7 @@ export default {
       default: true
     },
     code: {
-      type: String,
+      type: [String, Object],
       default: undefined
     },
     styleTokens
@@ -81,6 +82,12 @@ export default {
     }
   },
   computed: {
+    formattedCode: function () {
+      if (typeof this.code === 'object' && this.code !== null) {
+        return serializeJavaScript(this.code);
+      }
+      return this.code;
+    },
     language: function () {
       if (this.code.trim().startsWith('<')) {
         return XML;


### PR DESCRIPTION
### Summary
- The `code` prop in `DoxenCodeBox` now supports both **String** and **Object** types.
- If an object is passed, it is automatically **formatted using `serializeJavaScript`** before rendering.

### Why?
This allows developers to **easily display formatted JavaScript objects** without manually converting them to strings.

### Changes
- Updated `props` to null so it can accept any input.
- Added `formattedCode` computed property
- Used `serializeJavaScript` when `code` is an object
- Updated the template to use `formattedCode`

Closes: #149 
