### PR TITLE
Props playground events

### DIFF
--- a/app/helpers/codeSnippets.js
+++ b/app/helpers/codeSnippets.js
@@ -321,11 +321,18 @@ export const CUSTOM_COMPONENTS_DEMO_EXAMPLE = unindent(`
     component: MyComponent,
     propsToDemo: {
       color: {
+        // Provide your own component for the playground
         component: MyCustomColorPicker,
+        // Pass in props to MyCustomColorPicker
         props: {
           // Default value to demo
           modelValue: 'red'
-          // any other props your custom component takes
+        },
+        // You can listen to events emitted from MyCustomColorPicker
+        events: {
+          'update:modelValue': function (value) {
+            console.log({ value });
+          }
         }
       }
     }
@@ -344,11 +351,18 @@ export const CUSTOM_COMPONENTS_OPTIONS_EXAMPLE = unindent(`
     name: 'MyComponent',
     props: {
       color: {
+        // Provide your own component for the playground
         component: MyCustomColorPicker,
+        // Pass in props to MyCustomColorPicker
         props: {
           // Default value to demo
           modelValue: 'red'
-          // any other props your custom component takes
+        },
+        // You can listen to events emitted from MyCustomColorPicker
+        events: {
+          'update:modelValue': function (value) {
+            console.log({ value });
+          }
         }
       }
     }
@@ -370,11 +384,18 @@ export const CUSTOM_COMPONENTS_SCRIPT_SETUP_EXAMPLE = unindent(`
 
   defineProps({
     color: {
+      // Provide your own component for the playground
       component: MyCustomColorPicker,
+      // Pass in props to MyCustomColorPicker
       props: {
         // Default value to demo
         modelValue: 'red'
-        // any other props your custom component takes
+      },
+      // You can listen to events emitted from MyCustomColorPicker
+      events: {
+        'update:modelValue': function (value) {
+          console.log({ value });
+        }
       }
     }
   });

--- a/lib/helpers/demoHelpers.js
+++ b/lib/helpers/demoHelpers.js
@@ -633,18 +633,19 @@ export const autoGeneratePlaygroundProps = function (props, components, styleTok
       };
     }
 
-    if (typeof(props[propName]) === 'object') {
-      props[propName].events = events;
-      if (
-        props[propName]?.props &&
-        typeof(props[propName].props) === 'object' &&
-        !Array.isArray(props[propName].props)
-      ) {
-        playgroundProps[propName].props = {
-          ...playgroundProps[propName].props,
-          ...props[propName].props
-        };
-      }
+    if (
+      props[propName]?.props &&
+      typeof(props[propName].props) === 'object' &&
+      !Array.isArray(props[propName].props)
+    ) {
+      playgroundProps[propName].props = {
+        ...playgroundProps[propName].props,
+        ...props[propName].props
+      };
+    }
+
+    if (typeof(playgroundProps[propName]) === 'object') {
+      playgroundProps[propName].events = events;
     }
   }
 

--- a/lib/helpers/demoHelpers.js
+++ b/lib/helpers/demoHelpers.js
@@ -481,6 +481,7 @@ export const autoGeneratePlaygroundProps = function (props, components, styleTok
   }
   for (const propName in props) {
     const prop = props[propName];
+    const events = prop.events || {};
     const typeConstructor = prop.type;
     const isRequired = prop.required;
     const hasDefault = 'default' in prop;
@@ -632,15 +633,18 @@ export const autoGeneratePlaygroundProps = function (props, components, styleTok
       };
     }
 
-    if (
-      props[propName]?.props &&
-      typeof(props[propName].props) === 'object' &&
-      !Array.isArray(props[propName].props)
-    ) {
-      playgroundProps[propName].props = {
-        ...playgroundProps[propName].props,
-        ...props[propName].props
-      };
+    if (typeof(props[propName]) === 'object') {
+      props[propName].events = events;
+      if (
+        props[propName]?.props &&
+        typeof(props[propName].props) === 'object' &&
+        !Array.isArray(props[propName].props)
+      ) {
+        playgroundProps[propName].props = {
+          ...playgroundProps[propName].props,
+          ...props[propName].props
+        };
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,18 @@
 {
   "name": "vue-doxen",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vue-doxen",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
-      "dependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.41.0"
-      },
       "devDependencies": {
         "@babel/eslint-parser": "^7.27.1",
         "@highlightjs/vue-plugin": "2.1.2",
         "@vitejs/plugin-vue": "^5.2.4",
-        "@vitest/coverage-v8": "^3.1.3",
+        "@vitest/coverage-v8": "^3.1.4",
         "@vue/test-utils": "^2.4.6",
         "axe-core": "4.0.0",
         "babel-eslint": "^10.1.0",
@@ -41,7 +38,7 @@
         "sass": "^1.89.0",
         "vite": "^6.3.5",
         "vite-plugin-vue-devtools": "^7.7.6",
-        "vitest": "^3.1.2",
+        "vitest": "^3.1.4",
         "vue": "^3.5.14",
         "vue-axe": "^3.1.2",
         "vue-options-api-constants-plugin": "^1.0.3",
@@ -2203,9 +2200,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.3.tgz",
-      "integrity": "sha512-cj76U5gXCl3g88KSnf80kof6+6w+K4BjOflCl7t6yRJPDuCrHtVu0SgNYOUARJOL5TI8RScDbm5x4s1/P9bvpw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.1.4.tgz",
+      "integrity": "sha512-G4p6OtioySL+hPV7Y6JHlhpsODbJzt1ndwHAFkyk6vVjpK03PFsKnauZIzcd0PrK4zAbc5lc+jeZ+eNGiMA+iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2226,8 +2223,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.1.3",
-        "vitest": "3.1.3"
+        "@vitest/browser": "3.1.4",
+        "vitest": "3.1.4"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -2236,14 +2233,14 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.3.tgz",
-      "integrity": "sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.4.tgz",
+      "integrity": "sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.3",
-        "@vitest/utils": "3.1.3",
+        "@vitest/spy": "3.1.4",
+        "@vitest/utils": "3.1.4",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -2252,13 +2249,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.3.tgz",
-      "integrity": "sha512-PJbLjonJK82uCWHjzgBJZuR7zmAOrSvKk1QBxrennDIgtH4uK0TB1PvYmc0XBCigxxtiAVPfWtAdy4lpz8SQGQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.4.tgz",
+      "integrity": "sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.3",
+        "@vitest/spy": "3.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -2279,9 +2276,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.3.tgz",
-      "integrity": "sha512-i6FDiBeJUGLDKADw2Gb01UtUNb12yyXAqC/mmRWuYl+m/U9GS7s8us5ONmGkGpUUo7/iAYzI2ePVfOZTYvUifA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.4.tgz",
+      "integrity": "sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2292,13 +2289,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.3.tgz",
-      "integrity": "sha512-Tae+ogtlNfFei5DggOsSUvkIaSuVywujMj6HzR97AHK6XK8i3BuVyIifWAm/sE3a15lF5RH9yQIrbXYuo0IFyA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.4.tgz",
+      "integrity": "sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.1.3",
+        "@vitest/utils": "3.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2306,13 +2303,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.3.tgz",
-      "integrity": "sha512-XVa5OPNTYUsyqG9skuUkFzAeFnEzDp8hQu7kZ0N25B1+6KjGm4hWLtURyBbsIAOekfWQ7Wuz/N/XXzgYO3deWQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.4.tgz",
+      "integrity": "sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.3",
+        "@vitest/pretty-format": "3.1.4",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -2321,9 +2318,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.3.tgz",
-      "integrity": "sha512-x6w+ctOEmEXdWaa6TO4ilb7l9DxPR5bwEb6hILKuxfU1NqWT2mpJD9NJN7t3OTfxmVlOMrvtoFJGdgyzZ605lQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.4.tgz",
+      "integrity": "sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2334,13 +2331,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.3.tgz",
-      "integrity": "sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.3",
+        "@vitest/pretty-format": "3.1.4",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -8586,9 +8583,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8763,9 +8760,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.3.tgz",
-      "integrity": "sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.4.tgz",
+      "integrity": "sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8889,19 +8886,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.3.tgz",
-      "integrity": "sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.4.tgz",
+      "integrity": "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.1.3",
-        "@vitest/mocker": "3.1.3",
-        "@vitest/pretty-format": "^3.1.3",
-        "@vitest/runner": "3.1.3",
-        "@vitest/snapshot": "3.1.3",
-        "@vitest/spy": "3.1.3",
-        "@vitest/utils": "3.1.3",
+        "@vitest/expect": "3.1.4",
+        "@vitest/mocker": "3.1.4",
+        "@vitest/pretty-format": "^3.1.4",
+        "@vitest/runner": "3.1.4",
+        "@vitest/snapshot": "3.1.4",
+        "@vitest/spy": "3.1.4",
+        "@vitest/utils": "3.1.4",
         "chai": "^5.2.0",
         "debug": "^4.4.0",
         "expect-type": "^1.2.1",
@@ -8914,7 +8911,7 @@
         "tinypool": "^1.0.2",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.1.3",
+        "vite-node": "3.1.4",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -8930,8 +8927,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.1.3",
-        "@vitest/ui": "3.1.3",
+        "@vitest/browser": "3.1.4",
+        "@vitest/ui": "3.1.4",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-doxen",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "The world's best Vue.js component documentation tool!",
   "scripts": {
     "start": "vite dev --config vite.config.docs.js",
@@ -15,6 +15,7 @@
     "unit": "cross-env TZ=America/New_York vitest --coverage --config vite.config.lib.js",
     "test": "cross-env TZ=America/New_York vitest run --coverage --config vite.config.lib.js",
     "coverage": "cd tests && cd unit && cd coverage && node ../../../node_modules/npm-free-server/dist/server.js",
+    "bump": "npx --yes -- @jsdevtools/version-bump-prompt && npm i",
     "outdated": "npx --yes -- check-outdated --ignore-packages axe-core,eslint-config-tjw-import,eslint,eslint-config-tjw-jest,eslint-config-tjw-vue,eslint-config-tjw-base,eslint-plugin-import,eslint-plugin-vue,vue-axe --columns package,current,wanted,latest --types major,minor,patch"
   },
   "ManifestComments": [
@@ -26,7 +27,7 @@
     "@babel/eslint-parser": "^7.27.1",
     "@highlightjs/vue-plugin": "2.1.2",
     "@vitejs/plugin-vue": "^5.2.4",
-    "@vitest/coverage-v8": "^3.1.3",
+    "@vitest/coverage-v8": "^3.1.4",
     "@vue/test-utils": "^2.4.6",
     "axe-core": "4.0.0",
     "babel-eslint": "^10.1.0",
@@ -52,7 +53,7 @@
     "sass": "^1.89.0",
     "vite": "^6.3.5",
     "vite-plugin-vue-devtools": "^7.7.6",
-    "vitest": "^3.1.2",
+    "vitest": "^3.1.4",
     "vue": "^3.5.14",
     "vue-axe": "^3.1.2",
     "vue-options-api-constants-plugin": "^1.0.3",

--- a/tests/unit/lib/helpers/demoHelpers.test.js
+++ b/tests/unit/lib/helpers/demoHelpers.test.js
@@ -95,7 +95,8 @@ describe('Demo helpers', () => {
               asCode: true,
               label: 'Model Value',
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -114,7 +115,8 @@ describe('Demo helpers', () => {
             props: {
               label: 'Model Modifiers',
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -131,7 +133,8 @@ describe('Demo helpers', () => {
             props: {
               label: 'Some Messages',
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -148,7 +151,8 @@ describe('Demo helpers', () => {
             props: {
               label: 'Some Notes',
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -165,7 +169,8 @@ describe('Demo helpers', () => {
             props: {
               label: 'Some Comments',
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -189,7 +194,8 @@ describe('Demo helpers', () => {
               min: 20,
               max: 30,
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -209,7 +215,8 @@ describe('Demo helpers', () => {
               label: 'Amount',
               modelValue: undefined,
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -242,7 +249,8 @@ describe('Demo helpers', () => {
                 }
               ],
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -290,7 +298,8 @@ describe('Demo helpers', () => {
                 }
               ],
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -310,7 +319,8 @@ describe('Demo helpers', () => {
               name: 'Disabled',
               modelValue: false,
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -331,7 +341,8 @@ describe('Demo helpers', () => {
               label: 'Colors',
               modelValue: [],
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -352,7 +363,8 @@ describe('Demo helpers', () => {
               label: 'User',
               modelValue: {},
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -373,7 +385,8 @@ describe('Demo helpers', () => {
               label: 'User',
               modelValue: {},
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -392,7 +405,8 @@ describe('Demo helpers', () => {
             props: {
               label: 'Action',
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -413,7 +427,8 @@ describe('Demo helpers', () => {
               label: 'Action',
               modelValue: expect.any(Function),
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -431,7 +446,8 @@ describe('Demo helpers', () => {
               label: 'Name',
               modelValue: 'Name',
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -451,7 +467,8 @@ describe('Demo helpers', () => {
               label: 'Name',
               modelValue: 'Text',
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });
@@ -474,7 +491,8 @@ describe('Demo helpers', () => {
               label: 'Amount',
               modelValue: 30,
               styleTokens
-            }
+            },
+            events: {}
           }
         });
     });


### PR DESCRIPTION
Adds support for listening to emitted events on all playground prop components. Previously it only worked if you passed in a custom component.

**Checklist:**

* [x] Update dependencies
* [x] Bump
